### PR TITLE
Fix PyVCF3 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __versionstr__ = ".".join(map(str, VERSION))
 here = path.abspath(path.dirname(__file__))
 installation_requirements = [
     "requests>=2.0.0, <3.0.0",
-    "PyVCF3>=1.0.0",
+    "PyVCF3>=1.0.1",
     "jsonmodels>=2.2",
 ]
 if sys.version_info < (3, 4):


### PR DESCRIPTION
If a user has a python virtual environment with PyVCF3==1.0.0 and then install the varsome api client, the PyVCF3 will not be updated since it meets the project’s requirement which is PyVCF3>=1.0.0. However this leads to an error:
```
$ varsome_api_annotate_vcf.py -g hg19 -k ${API_KEY} -i plain_variants.vcf -o out.vcf -p add-all-data=1
Traceback (most recent call last):
  File "/tmp_varsome_api/test_varsome_102423/bin/varsome_api_annotate_vcf.py", line 19, in <module>
    from varsome_api.vcf import VCFAnnotator
  File "/tmp_varsome_api/test_varsome_102423/lib/python3.7/site-packages/varsome_api/vcf.py", line 20, in <module>
    from vcf.parser import _Info, _encode_type
ImportError: cannot import name '_encode_type' from 'vcf.parser' (/tmp_varsome_api/test_varsome_102423/lib/python3.7/site-packages/vcf/parser.py)
 ```

We need to update the requirement to PyVCF3>=1.0.1 to resolve this.